### PR TITLE
Fix: Oathkeeper CORS

### DIFF
--- a/kubernetes/app/api-db.yaml
+++ b/kubernetes/app/api-db.yaml
@@ -20,6 +20,7 @@ spec:
       containers:
       - image: postgres:16.2
         name: postgres
+        imagePullPolicy: IfNotPresent
         resources:
           requests:
             memory: 64Mi
@@ -36,6 +37,7 @@ spec:
               name: db-secrets
       - image: quay.io/prometheuscommunity/postgres-exporter:v0.15.0
         name: postgres-exporter
+        imagePullPolicy: IfNotPresent
         resources:
           requests:
             memory: 64Mi

--- a/kubernetes/app/api.yaml
+++ b/kubernetes/app/api.yaml
@@ -17,6 +17,7 @@ spec:
       containers:
       - image: registry.scs.community/status-page/status-page-api@sha256:bb1c8f04f16471511cf56e7111bd358fba528de1321b8056fe8f18e6cb3a0516
         name: status-page-api
+        imagePullPolicy: IfNotPresent
         resources:
           requests:
             memory: 64Mi

--- a/kubernetes/app/dex.yaml
+++ b/kubernetes/app/dex.yaml
@@ -17,6 +17,7 @@ spec:
       containers:
       - image: dexidp/dex:v2.38.0
         name: dex
+        imagePullPolicy: IfNotPresent
         resources:
           requests:
             memory: 64Mi

--- a/kubernetes/app/oathkeeper.yaml
+++ b/kubernetes/app/oathkeeper.yaml
@@ -17,6 +17,7 @@ spec:
       containers:
       - image: oryd/oathkeeper:v0.40.7
         name: oathkeeper
+        imagePullPolicy: IfNotPresent
         resources:
           requests:
             memory: 64Mi

--- a/kubernetes/app/web.yaml
+++ b/kubernetes/app/web.yaml
@@ -17,6 +17,7 @@ spec:
       containers:
       - image: registry.scs.community/status-page/status-page-web@sha256:56ab55f8372349fd82c7bf94f5b57168878e04bf3c7152ae08c98da5117efab4
         name: status-page-web
+        imagePullPolicy: IfNotPresent
         resources:
           requests:
             memory: 64Mi

--- a/kubernetes/environments/k3s/dex/dex.env
+++ b/kubernetes/environments/k3s/dex/dex.env
@@ -1,4 +1,4 @@
 GITHUB_CLIENT_ID=Iv1.b0baaf69d8ce504b
 GITHUB_ORG=SovereignCloudStack
 CLIENT_NAME=Status Page Local
-DEX_ALLOWED_ORIGINS=<your-web-domain>
+DEX_ALLOWED_ORIGINS=https://<your-web-domain>

--- a/kubernetes/environments/k3s/oathkeeper/config.yaml
+++ b/kubernetes/environments/k3s/oathkeeper/config.yaml
@@ -3,6 +3,20 @@ serve:
     port: 4455
   api:
     port: 4456
+    cors:
+      enabled: true
+      allowed_origins:
+        - https://<your-web-domain>
+      allow_credentials: true
+      allowed_methods:
+        - POST
+        - PATCH
+        - DELETE
+      allowed_headers:
+        - Authorization
+        - Content-Type
+      exposed_headers:
+        - Content-Type
   prometheus:
     port: 9000
     hide_request_paths: true

--- a/kubernetes/environments/k3s/oathkeeper/config.yaml
+++ b/kubernetes/environments/k3s/oathkeeper/config.yaml
@@ -1,8 +1,6 @@
 serve:
   proxy:
     port: 4455
-  api:
-    port: 4456
     cors:
       enabled: true
       allowed_origins:
@@ -17,6 +15,8 @@ serve:
         - Content-Type
       exposed_headers:
         - Content-Type
+  api:
+    port: 4456
   prometheus:
     port: 9000
     hide_request_paths: true

--- a/kubernetes/environments/k3s/oathkeeper/rules.yaml
+++ b/kubernetes/environments/k3s/oathkeeper/rules.yaml
@@ -21,7 +21,6 @@
   match:
     url: https://<your-api-domain>/phases
     methods:
-      - OPTIONS
       - POST
   authenticators:
     - handler: jwt
@@ -53,7 +52,6 @@
   match:
     url: https://<your-api-domain>/impacttypes
     methods:
-      - OPTIONS
       - POST
   authenticators:
     - handler: jwt
@@ -84,7 +82,6 @@
   match:
     url: https://<your-api-domain>/impacttypes/<[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}>
     methods:
-      - OPTIONS
       - PATCH
       - DELETE
   authenticators:
@@ -117,7 +114,6 @@
   match:
     url: https://<your-api-domain>/severities
     methods:
-      - OPTIONS
       - POST
   authenticators:
     - handler: jwt
@@ -148,7 +144,6 @@
   match:
     url: https://<your-api-domain>/severities/<[\w-]*>
     methods:
-      - OPTIONS
       - PATCH
       - DELETE
   authenticators:
@@ -181,7 +176,6 @@
   match:
     url: https://<your-api-domain>/components
     methods:
-      - OPTIONS
       - POST
   authenticators:
     - handler: jwt
@@ -212,7 +206,6 @@
   match:
     url: https://<your-api-domain>/components/<[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}>
     methods:
-      - OPTIONS
       - PATCH
       - DELETE
   authenticators:
@@ -245,7 +238,6 @@
   match:
     url: https://<your-api-domain>/incidents
     methods:
-      - OPTIONS
       - POST
   authenticators:
     - handler: jwt
@@ -276,7 +268,6 @@
   match:
     url: https://<your-api-domain>/incidents/<[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}>
     methods:
-      - OPTIONS
       - PATCH
       - DELETE
   authenticators:
@@ -309,7 +300,6 @@
   match:
     url: https://<your-api-domain>/incidents/<[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}>/updates
     methods:
-      - OPTIONS
       - POST
   authenticators:
     - handler: jwt
@@ -340,7 +330,6 @@
   match:
     url: https://<your-api-domain>/incidents/<[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}>/updates/<[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}>
     methods:
-      - OPTIONS
       - PATCH
       - DELETE
   authenticators:

--- a/kubernetes/environments/kind/oathkeeper/config.yaml
+++ b/kubernetes/environments/kind/oathkeeper/config.yaml
@@ -1,6 +1,21 @@
 serve:
   proxy:
     port: 4455
+    cors:
+      enabled: true
+      allowed_origins:
+        - http://web.localhost:8080
+        - http://localhost:4200
+      allow_credentials: true
+      allowed_methods:
+        - POST
+        - PATCH
+        - DELETE
+      allowed_headers:
+        - Authorization
+        - Content-Type
+      exposed_headers:
+        - Content-Type
   api:
     port: 4456
   prometheus:

--- a/kubernetes/environments/kind/oathkeeper/rules.yaml
+++ b/kubernetes/environments/kind/oathkeeper/rules.yaml
@@ -21,7 +21,6 @@
   match:
     url: http://api.localhost:8080/phases
     methods:
-      - OPTIONS
       - POST
   authenticators:
     - handler: jwt
@@ -53,7 +52,6 @@
   match:
     url: http://api.localhost:8080/impacttypes
     methods:
-      - OPTIONS
       - POST
   authenticators:
     - handler: jwt
@@ -84,7 +82,6 @@
   match:
     url: http://api.localhost:8080/impacttypes/<[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}>
     methods:
-      - OPTIONS
       - PATCH
       - DELETE
   authenticators:
@@ -117,7 +114,6 @@
   match:
     url: http://api.localhost:8080/severities
     methods:
-      - OPTIONS
       - POST
   authenticators:
     - handler: jwt
@@ -148,7 +144,6 @@
   match:
     url: http://api.localhost:8080/severities/<[\w-]*>
     methods:
-      - OPTIONS
       - PATCH
       - DELETE
   authenticators:
@@ -181,7 +176,6 @@
   match:
     url: http://api.localhost:8080/components
     methods:
-      - OPTIONS
       - POST
   authenticators:
     - handler: jwt
@@ -212,7 +206,6 @@
   match:
     url: http://api.localhost:8080/components/<[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}>
     methods:
-      - OPTIONS
       - PATCH
       - DELETE
   authenticators:
@@ -245,7 +238,6 @@
   match:
     url: http://api.localhost:8080/incidents
     methods:
-      - OPTIONS
       - POST
   authenticators:
     - handler: jwt
@@ -276,7 +268,6 @@
   match:
     url: http://api.localhost:8080/incidents/<[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}>
     methods:
-      - OPTIONS
       - PATCH
       - DELETE
   authenticators:
@@ -309,7 +300,6 @@
   match:
     url: http://api.localhost:8080/incidents/<[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}>/updates
     methods:
-      - OPTIONS
       - POST
   authenticators:
     - handler: jwt
@@ -340,7 +330,6 @@
   match:
     url: http://api.localhost:8080/incidents/<[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}>/updates/<[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}>
     methods:
-      - OPTIONS
       - PATCH
       - DELETE
   authenticators:

--- a/kubernetes/environments/scs-public/oathkeeper/config.yaml
+++ b/kubernetes/environments/scs-public/oathkeeper/config.yaml
@@ -1,6 +1,20 @@
 serve:
   proxy:
     port: 4455
+    cors:
+      enabled: true
+      allowed_origins:
+        - https://status.k8s.scs.community/keys
+      allow_credentials: true
+      allowed_methods:
+        - POST
+        - PATCH
+        - DELETE
+      allowed_headers:
+        - Authorization
+        - Content-Type
+      exposed_headers:
+        - Content-Type
   api:
     port: 4456
   prometheus:

--- a/kubernetes/environments/scs-public/oathkeeper/rules.yaml
+++ b/kubernetes/environments/scs-public/oathkeeper/rules.yaml
@@ -21,7 +21,6 @@
   match:
     url: https://status-api.k8s.scs.community/phases
     methods:
-      - OPTIONS
       - POST
   authenticators:
     - handler: jwt
@@ -53,7 +52,6 @@
   match:
     url: https://status-api.k8s.scs.community/impacttypes
     methods:
-      - OPTIONS
       - POST
   authenticators:
     - handler: jwt
@@ -84,7 +82,6 @@
   match:
     url: https://status-api.k8s.scs.community/impacttypes/<[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}>
     methods:
-      - OPTIONS
       - PATCH
       - DELETE
   authenticators:
@@ -117,7 +114,6 @@
   match:
     url: https://status-api.k8s.scs.community/severities
     methods:
-      - OPTIONS
       - POST
   authenticators:
     - handler: jwt
@@ -148,7 +144,6 @@
   match:
     url: https://status-api.k8s.scs.community/severities/<[\w-]*>
     methods:
-      - OPTIONS
       - PATCH
       - DELETE
   authenticators:
@@ -181,7 +176,6 @@
   match:
     url: https://status-api.k8s.scs.community/components
     methods:
-      - OPTIONS
       - POST
   authenticators:
     - handler: jwt
@@ -212,7 +206,6 @@
   match:
     url: https://status-api.k8s.scs.community/components/<[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}>
     methods:
-      - OPTIONS
       - PATCH
       - DELETE
   authenticators:
@@ -245,7 +238,6 @@
   match:
     url: https://status-api.k8s.scs.community/incidents
     methods:
-      - OPTIONS
       - POST
   authenticators:
     - handler: jwt
@@ -276,7 +268,6 @@
   match:
     url: https://status-api.k8s.scs.community/incidents/<[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}>
     methods:
-      - OPTIONS
       - PATCH
       - DELETE
   authenticators:
@@ -309,7 +300,6 @@
   match:
     url: https://status-api.k8s.scs.community/incidents/<[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}>/updates
     methods:
-      - OPTIONS
       - POST
   authenticators:
     - handler: jwt
@@ -340,7 +330,6 @@
   match:
     url: https://status-api.k8s.scs.community/incidents/<[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}>/updates/<[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}>
     methods:
-      - OPTIONS
       - PATCH
       - DELETE
   authenticators:


### PR DESCRIPTION
Oathkeeper handles the preflight before proxing the API request to the backend.

Allowed origins must be set, to be able to use allow credentials, to send the token.